### PR TITLE
Make all work

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -4,3 +4,4 @@ David Bartle <captindave@gmail.com>
 Contributors:
 clinty
 serpman
+iffy

--- a/ofxhome/__init__.py
+++ b/ofxhome/__init__.py
@@ -29,7 +29,7 @@ class OFXHome:
 
         See also: OFXHome.search()
         """
-        return search()
+        return OFXHome.search()
 
     @staticmethod
     def search(name=None):


### PR DESCRIPTION
Otherwise I get this:

```
>>> from ofxhome import OFXHome
>>> OFXHome.all()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "ofxhome/__init__.py", line 32, in all
    return search()
NameError: global name 'search' is not defined
```
